### PR TITLE
add `resolve` fn to handle `kepler://<v>:<oid>/<cid>` URIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,17 @@ export class Kepler<A extends Authenticator> {
         private auth: A,
     ) { }
 
+    public async resolve<T>(keplerUri: string, authenticate: boolean = true): Promise<T> {
+        if (!keplerUri.startsWith("kepler://")) throw new Error("Invalid Kepler URI");
+
+        let [versionedOrbit, cid] = keplerUri.split("/").slice(-2);
+        let orbit = versionedOrbit.split(":").pop();
+
+        if (!orbit || !cid) throw new Error("Invalid Kepler URI");
+
+        return await this.get(orbit, cid, authenticate)
+    }
+
     public async get<T>(orbit: string, cid: string, authenticate: boolean = true): Promise<T> {
         return await this.orbit(orbit).get(cid, authenticate)
     }


### PR DESCRIPTION
Kepler has a uri scheme independent of host. This PR adds a method to the SDK to attempt resolution of said URIs via it's provided hosts.