### PR TITLE
orbit creation

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,7 +16,7 @@ describe('Kepler Client', () => {
     let authn: Authenticator;
 
     beforeAll(async () => {
-        authn = await authenticator(new DAppClient({ name: "Test Client" }));
+        authn = await authenticator(new DAppClient({ name: "Test Client" }), 'test-domain');
     })
 
     it('Encodes strings correctly', () => expect(stringEncoder('message')).toBe('0501000000076d657373616765'))
@@ -24,7 +24,7 @@ describe('Kepler Client', () => {
     it('Creates auth tokens', async () => {
         const cid = 'uAYAEHiB0uGRNPXEMdA9L-lXR2MKIZzKlgW1z6Ug4fSv3LRSPfQ';
         const orbit = 'uAYAEHiB_A0nLzANfXNkW5WCju51Td_INJ6UacFK7qY6zejzKoA';
-        const auth = await authn(orbit, cid, Action.get)
+        const auth = await authn.content(orbit, [cid], Action.get)
     })
 
     it('naive integration test', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,26 @@ export class Kepler<A extends Authenticator> {
     public orbit(orbit: string): Orbit<A> {
         return new Orbit(this.url, orbit, this.auth);
     }
+
+    public async createOrbit<T>(first: T, ...rest: T[]): Promise<Response> {
+        const auth = await this.auth.createOrbit(await Promise.all([first, ...rest].map(async (c) => await makeCid(c))))
+        if (rest.length >= 1) {
+            return await fetch(this.url, {
+                method: 'POST',
+                body: await makeFormRequest([first, ...rest]),
+                headers: { 'Authorization': auth}
+            });
+        } else {
+            return await fetch(this.url, {
+                method: 'POST',
+                body: JSON.stringify(first),
+                headers: {
+                    'Authorization': auth,
+                    'Content-Type': 'application/json'
+                }
+            })
+        }
+    }
 }
 
 export class Orbit<A extends Authenticator> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export const authenticator: AuthFactory<DAppClient> = async (client, domain: str
             return auth + " " + signature
         },
         createOrbit: async (cids: string[]): Promise<string> => {
-            const auth = await createTzAuthCreationMessage(pk, pkh, cids, 'TZProfiles')
+            const auth = await createTzAuthCreationMessage(pk, pkh, cids, domain)
             const { signature } = await client.requestSignPayload({
                 signingType: SigningType.MICHELINE,
                 payload: stringEncoder(auth)
@@ -68,7 +68,7 @@ export class Kepler<A extends Authenticator> {
     }
 
     // typed so that it takes at least 1 element
-    public async put<T>(orbit: string, first: T, ...rest: T[]): Promise<Response> {
+    public async put(orbit: string, first: any, ...rest: any[]): Promise<Response> {
         return await this.orbit(orbit).put(first, ...rest)
     }
 
@@ -80,7 +80,7 @@ export class Kepler<A extends Authenticator> {
         return new Orbit(this.url, orbit, this.auth);
     }
 
-    public async createOrbit<T>(first: T, ...rest: T[]): Promise<Response> {
+    public async createOrbit(first: any, ...rest: any[]): Promise<Response> {
         const auth = await this.auth.createOrbit(await Promise.all([first, ...rest].map(async (c) => await makeCid(c))))
         if (rest.length >= 1) {
             return await fetch(this.url, {
@@ -119,7 +119,7 @@ export class Orbit<A extends Authenticator> {
         })
     }
 
-    public async put<T>(first: T, ...rest: T[]): Promise<Response> {
+    public async put(first: any, ...rest: any[]): Promise<Response> {
         const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(c))), Action.put)
         if (rest.length >= 1) {
             return await fetch(makeOrbitPath(this.url, this.orbit), {


### PR DESCRIPTION
changes required for compatibility with the updates from the [multi-orbit kepler PR](https://github.com/spruceid/kepler/pull/17). specifically:
- add `createOrbit` fn to `Authenticator` and impl for `DAppClient`
- clean up utility functions
- add `createOrbit` fn to `Kepler`, currently it returns a `Promise<Response>` for transparency, but could alternatively return a `Promise<Orbit>`
- types all `.put` functions (including `createOrbit`) to take `any` (there are no convenient types yet for "raw json")