### PR TITLE
remove generics from Kepler class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,10 @@ export const authenticator: AuthFactory<DAppClient> = async (client) =>
         return auth + " " + signature
     }
 
-export class Kepler<A extends Authenticator> {
+export class Kepler {
     constructor(
         private url: string,
-        private auth: A,
+        private auth: Authenticator,
     ) { }
 
     public async resolve(keplerUri: string, authenticate: boolean = true): Promise<Response> {


### PR DESCRIPTION
removes the `<A extends Authenticator>` type param from `Kepler` and `Orbit`, it proved to be unnecessary and cumbersome