### PR TITLE
fix CID generation text encoding

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Kepler, Orbit, Action, Authenticator, authenticator, stringEncoder } from './';
+import { Kepler, Orbit, Action, Authenticator, authenticator, stringEncoder, getOrbitId } from './';
 import { DAppClient } from '@airgap/beacon-sdk';
 import { InMemorySigner } from '@taquito/signer';
 
@@ -25,6 +25,14 @@ describe('Kepler Client', () => {
         const cid = 'uAYAEHiB0uGRNPXEMdA9L-lXR2MKIZzKlgW1z6Ug4fSv3LRSPfQ';
         const orbit = 'uAYAEHiB_A0nLzANfXNkW5WCju51Td_INJ6UacFK7qY6zejzKoA';
         const auth = await authn.content(orbit, [cid], Action.get)
+    })
+
+    it('Generates correct orbit IDs', async () => {
+        const oid = "zCT5htkeDcXL4DP4b7MMSNywaSRVRxTTynbvpKcYkdZKtoF3WgXb"
+        const pkh = "tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy"
+        const domain = "TZProfiles"
+
+        return await expect(getOrbitId(pkh, domain)).resolves.toEqual(oid)
     })
 
     it('naive integration test', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ const addContent = async <T>(form: FormData, content: T) => {
     );
 }
 
-const makeCid = async <T>(content: T, codec: string = 'json'): Promise<string> => new CID(1, codec, await multihashing(new TextEncoder().encode(JSON.stringify(content)), 'blake2b-256')).toString('base58btc')
+const makeCid = async <T>(content: T, codec: string = 'json'): Promise<string> => new CID(1, codec, await multihashing(new TextEncoder().encode(typeof content === 'string' ? content : JSON.stringify(content)), 'blake2b-256')).toString('base58btc')
 
 const toPaddedHex = (n: number, padLen: number = 8, padChar: string = '0'): string =>
     n.toString(16).padStart(padLen, padChar)


### PR DESCRIPTION
CID generation used JSON.stringify, which would wrap a string in `"`. Raw strings should be encoded without the quotations for correct orbit-id generation.