### PR TITLE
tz address as param in OID generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kepler-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Kepler, Action, Authenticator, authenticator, stringEncoder, getOrbitId } from './';
+import { Kepler, Action, Authenticator, authenticator, stringEncoder, getOrbitId, orbitParams } from './';
 import { DAppClient } from '@airgap/beacon-sdk';
 import { InMemorySigner } from '@taquito/signer';
 
@@ -27,8 +27,16 @@ describe('Kepler Client', () => {
         const auth = await authn.content(orbit, [cid], Action.get)
     })
 
+    it('Generates correct orbit parameters', async () => {
+        const params = ";address=tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy;domain=kepler.tzprofiles.com;index=0"
+        const pkh = "tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy"
+        const domain = "kepler.tzprofiles.com"
+
+        return expect(orbitParams({ address: pkh, domain, index: 0 })).toEqual(params)
+    })
+
     it('Generates correct orbit IDs', async () => {
-        const oid = "zCT5htkdxg8ioQ9pA3C2qGQsFafGeAMvrHC572oTCTpbo358BBHQ"
+        const oid = "zCT5htkeBtA6Qu5YF4vPkQcfeqy3pY4m8zxGdUKUiPgtPEbY3rHy"
         const pkh = "tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy"
         const domain = "kepler.tzprofiles.com"
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,7 @@ describe('Kepler Client', () => {
     })
 
     it('Generates correct orbit IDs', async () => {
-        const oid = "zCT5htkeBWqcgBf37wwFThnV8sYYoddo8hzPr3j9TToTi1ctZ7mh"
+        const oid = "zCT5htke5f3z7C77jRXmmmHwHHF2xXaoNuQiQ96wmp3nGke8PxpL"
         const pkh = "tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy"
         const domain = "kepler.tzrofiles.com"
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Kepler, Orbit, Action, Authenticator, authenticator, stringEncoder, getOrbitId } from './';
+import { Kepler, Action, Authenticator, authenticator, stringEncoder, getOrbitId } from './';
 import { DAppClient } from '@airgap/beacon-sdk';
 import { InMemorySigner } from '@taquito/signer';
 
@@ -28,9 +28,9 @@ describe('Kepler Client', () => {
     })
 
     it('Generates correct orbit IDs', async () => {
-        const oid = "zCT5htke5f3z7C77jRXmmmHwHHF2xXaoNuQiQ96wmp3nGke8PxpL"
+        const oid = "zCT5htkdxg8ioQ9pA3C2qGQsFafGeAMvrHC572oTCTpbo358BBHQ"
         const pkh = "tz1YSb7gXhgBw46nSXthhoSzhJdbQf9h92Gy"
-        const domain = "kepler.tzrofiles.com"
+        const domain = "kepler.tzprofiles.com"
 
         return await expect(getOrbitId(pkh, { domain, index: 0 })).resolves.toEqual(oid)
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ const toPaddedHex = (n: number, padLen: number = 8, padChar: string = '0'): stri
     n.toString(16).padStart(padLen, padChar)
 
 export const getOrbitId = async (pkh: string, params: { domain?: string; salt?: string; index?: number; } = {}): Promise<string> => {
-    return await makeCid(`tz:${pkh}${orbitParams(params)}`, 'raw');
+    return await makeCid(`tz${orbitParams({ address: pkh, ...params })}`, 'raw');
 }
 
 export const orbitParams = (params: { [k: string]: string | number }): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,12 +170,12 @@ export const getOrbitId = async (pkh: string, params: { domain?: string; salt?: 
 }
 
 export const orbitParams = (params: { [k: string]: string | number }): string => {
-    let p = new URLSearchParams();
+    let p = [];
     for (const [key, value] of Object.entries(params)) {
-        p.append(key, typeof value === 'string' ? value : value.toString())
+        p.push(`${key}=${typeof value === 'string' ? value : value.toString()}`);
     }
     p.sort();
-    return "?" + p.toString()
+    return ';' + p.join(';');
 }
 
 const createTzAuthContentMessage = (orbit: string, pk: string, pkh: string, action: Action, cids: string[], domain: string): string =>


### PR DESCRIPTION
Previously, the tz-form uri used for Orbit ID generation was `tz:<address>?<query-params>`. This PR updates this URIs to be of the form `tz;address=<address>;<matrix-params>`, where `<address>` is now a required matrix-param for tz-derived Orbit IDs. This is desirable as `tz:<address>` is not a path segment that can appear in valid URIs. Matrix params are chosen over query params to support params in kepler URIs of the form: `kepler://tz;<params>/<content-id>`, as query params may only occur in the final segment of a URI. Changes in this PR correspond to [PR #35 in Kepler](https://github.com/spruceid/kepler/pull/35).