### PR TITLE
S3 client interface

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFiles: ['jest-localstorage-mock']
+  setupFiles: ['jest-localstorage-mock'],
+  transform: {}
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,0 @@
-export default {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  setupFiles: ['jest-localstorage-mock'],
-  transform: {}
-};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "files": [
     "/dist"
   ],
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "setupFiles": ["jest-localstorage-mock"],
+    "transform": {}
+  },
   "type": "module",
   "devDependencies": {
     "@airgap/beacon-sdk": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -5,25 +5,31 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc -p .",
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "files": [
     "/dist"
   ],
+  "type": "module",
   "devDependencies": {
     "@airgap/beacon-sdk": "^2.2.3",
+    "@spruceid/didkit-wasm-node": "0.1.6",
+    "@spruceid/zcap-providers": "^0.1.1",
     "@taquito/signer": "^8.1.1",
     "@types/jest": "^26.0.22",
-    "@spruceid/didkit-wasm-node": "0.1.6",
+    "@types/mime-types": "^2.1.1",
+    "@types/node": "^16.11.6",
+    "fetch-blob": "^2.1.2",
     "jest": "^26.6.3",
     "jest-localstorage-mock": "^2.4.9",
+    "mime-types": "^2.1.33",
     "ts-jest": "^26.5.4",
+    "ts-node": "^10.4.0",
     "typescript": "^4.2.3",
-    "@spruceid/zcap-providers": "^0.1.1"
+    "walkdir": "^0.4.1"
   },
   "dependencies": {
     "cids": "^1.1.6",
-    "cross-blob": "^2.0.0",
     "cross-fetch": "^3.1.4",
     "form-data": "^4.0.0",
     "multihashing-async": "^2.1.2",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,9 @@
 import { Kepler, startSession, didVmToParams } from './';
 import { tz, didkey, Capabilities } from '@spruceid/zcap-providers';
 import * as didkit from '@spruceid/didkit-wasm-node';
-import fetch from 'cross-fetch';
+// import { Response } from 'cross-fetch';
+import Blob = require('fetch-blob');
+// import { Blob } from 'buffer';
 
 import { DAppClient } from '@airgap/beacon-sdk';
 import { InMemorySigner } from '@taquito/signer';
@@ -64,7 +66,8 @@ describe('Kepler Client', () => {
         const json2 = { hello: 'hey2' };
 
         // writer can write
-        const uri = await write.put(json).then(async res => {
+        // @ts-ignore
+        const uri = await write.put(new Blob([JSON.stringify(json)], { type: 'application/json' })).then(async res => {
             expect(res.status).toEqual(200);
             return res.text()
         });
@@ -75,7 +78,8 @@ describe('Kepler Client', () => {
         // reader can read
         await expect(read.get(cid).then(async (res) => await res.json())).resolves.toEqual(json)
         // reader cant write
-        await expect(read.put(json2)).resolves.toHaveProperty('status', 401);
+        // @ts-ignore
+        await expect(read.put(new Blob([JSON.stringify(json2)], { type: 'application/json' }))).resolves.toHaveProperty('status', 401);
         // reader cant delete
         await expect(read.del(cid)).resolves.toHaveProperty('status', 401);
 
@@ -98,7 +102,8 @@ describe('Kepler Client', () => {
 
         await new Promise(res => setTimeout(res, 4000));
         const json = { hello: "there" };
-        const res = await node1.put('key1', JSON.stringify(json), { "my-header": "my header value", "content-type": "application/json" });
+        // @ts-ignore
+        const res = await node1.put('key1', new Blob([JSON.stringify(json)], { type: 'application/json' }), { "my-header": "my header value" });
         expect(res.status).toEqual(200);
 
         const getRes1 = await node1.get('key1');

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,11 @@ export class Kepler {
     }
 
     public async new_id(): Promise<string> {
-        return await fetch(this.url + "/new_id").then(async res => await res.text());
+        return await fetch(this.url + "/peer/generate").then(async res => await res.text());
     }
 
     public async id_addr(id: string): Promise<string> {
-        return await fetch(this.url + "/relay").then(async res => await res.text() + "/p2p-circuit/p2p/" + id);
+        return await fetch(this.url + "/peer/relay").then(async res => await res.text() + "/p2p-circuit/p2p/" + id);
     }
 
     public async createOrbit(content: any[], params: { [key: string]: string | number } = {}, method: string = 'did'): Promise<Response> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { S3 } from './s3';
 export { zcapAuthenticator, startSession, didVmToParams } from './zcap';
 export { tzStringAuthenticator } from './tzString';
 export { Ipfs };
+export { S3 };
 
 export enum Action {
     get = 'GET',

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,13 +53,13 @@ export class Kepler {
         return await fetch(this.url + "/peer/relay").then(async res => await res.text() + "/p2p-circuit/p2p/" + id);
     }
 
-    public async createOrbit(content: any[], params: { [key: string]: string | number } = {}, method: string = 'did'): Promise<Response> {
-        const auth = await this.auth.createOrbit(await Promise.all(content.map(async (c) => await makeCid(c))), params, method)
+    public async createOrbit(content: Blob[], params: { [key: string]: string | number } = {}, method: string = 'did'): Promise<Response> {
+        const auth = await this.auth.createOrbit(await Promise.all(content.map(async (c) => await makeCid(new Uint8Array(await c.arrayBuffer())))), params, method)
         if (content.length === 1) {
             return await fetch(this.url, {
                 method: 'POST',
-                body: JSON.stringify(content[0]),
-                headers: { ...auth, ...{ 'Content-Type': 'application/json' } }
+                body: content[0],
+                headers: auth
             })
         } else if (content.length === 0) {
             return await fetch(this.url, {

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -1,0 +1,54 @@
+import { Action, Authenticator, makeCid } from "./index";
+import fetch from 'cross-fetch';
+
+export class Ipfs {
+    constructor(
+        private url: string,
+        private orbitId: string,
+        private auth: Authenticator,
+    ) { }
+
+    public get orbit(): string {
+        return this.orbitId
+    }
+
+    public async get(cid: string, authenticate: boolean = true): Promise<Response> {
+        return await fetch(makeContentPath(this.url, this.orbit, cid), {
+            method: "GET",
+            headers: authenticate ? { ...await this.auth.content(this.orbit, [cid], Action.get) } : undefined
+        })
+    }
+
+    public async put(first: any, ...rest: any[]): Promise<Response> {
+        const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(c))), Action.put)
+        if (rest.length >= 1) {
+            return await fetch(makeOrbitPath(this.url, this.orbit), {
+                method: "PUT",
+                // @ts-ignore
+                body: await makeFormRequest(first, ...rest),
+                headers: auth
+            })
+        } else {
+            return await fetch(makeOrbitPath(this.url, this.orbit), {
+                method: "PUT",
+                body: JSON.stringify(first),
+                headers: { ...auth, ...{ "Content-Type": "application/json" } }
+            })
+        }
+    }
+
+    public async del(cid: string): Promise<Response> {
+        return await fetch(makeContentPath(this.url, this.orbit, cid), {
+            method: 'DELETE',
+            headers: await this.auth.content(this.orbit, [cid], Action.delete)
+        })
+    }
+
+    public async list(): Promise<Response> {
+        return await fetch(makeOrbitPath(this.url, this.orbit), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+    }
+}
+
+const makeOrbitPath = (url: string, orbit: string): string => url + "/" + orbit
+
+const makeContentPath = (url: string, orbit: string, cid: string): string => makeOrbitPath(url, orbit) + "/" + cid

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -19,8 +19,8 @@ export class Ipfs {
         })
     }
 
-    public async put(first: any, ...rest: any[]): Promise<Response> {
-        const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(c))), Action.put)
+    public async put(first: Blob, ...rest: Blob[]): Promise<Response> {
+        const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(new Uint8Array(await c.arrayBuffer())))), Action.put)
         if (rest.length >= 1) {
             return await fetch(makeOrbitPath(this.url, this.orbit), {
                 method: "PUT",
@@ -31,7 +31,7 @@ export class Ipfs {
         } else {
             return await fetch(makeOrbitPath(this.url, this.orbit), {
                 method: "PUT",
-                body: JSON.stringify(first),
+                body: first,
                 headers: { ...auth, ...{ "Content-Type": "application/json" } }
             })
         }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -26,8 +26,8 @@ export class S3 {
         })
     }
 
-    public async put(key: string, value: any, metadata: { [key: string]: string }): Promise<Response> {
-        const cid = await makeCid(value, 'raw');
+    public async put(key: string, value: Blob, metadata: { [key: string]: string }): Promise<Response> {
+        const cid = await makeCid(new Uint8Array(await value.arrayBuffer()));
         const auth = await this.auth.content(this.orbit, [cid], Action.put)
         return await fetch(makeContentPath(this.url, this.orbit, key), {
             method: "PUT",

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,0 +1,53 @@
+import { Action, Authenticator, makeCid } from "./index";
+import fetch from 'cross-fetch';
+
+export class S3 {
+    constructor(
+        private url: string,
+        private orbitId: string,
+        private auth: Authenticator,
+    ) { }
+
+    public get orbit(): string {
+        return this.orbitId
+    }
+
+    public async get(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
+        return await fetch(makeContentPath(this.url, this.orbit, key, version), {
+            method: "GET",
+            headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
+        })
+    }
+
+    public async head(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
+        return await fetch(makeContentPath(this.url, this.orbit, key, version), {
+            method: "HEAD",
+            headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
+        })
+    }
+
+    public async put(key: string, value: any, metadata: { [key: string]: string }): Promise<Response> {
+        const cid = await makeCid(value, 'raw');
+        const auth = await this.auth.content(this.orbit, [cid], Action.put)
+        return await fetch(makeContentPath(this.url, this.orbit, key), {
+            method: "PUT",
+            body: value,
+            headers: { ...auth, ...metadata }
+        })
+    }
+
+    public async del(cid: string, version?: string): Promise<Response> {
+        return await fetch(makeContentPath(this.url, this.orbit, cid, version), {
+            method: 'DELETE',
+            headers: await this.auth.content(this.orbit, [cid], Action.delete)
+        })
+    }
+
+    public async list(): Promise<Response> {
+        return await fetch(makeOrbitPath(this.url, this.orbit), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+    }
+}
+
+const makeOrbitPath = (url: string, orbit: string): string => url + "/" + orbit + "/s3"
+
+const makeContentPath = (url: string, orbit: string, key: string, version?: string): string => makeOrbitPath(url, orbit) + "/" + key + (version ? `?version=${version}` : "")

--- a/src/tzString.ts
+++ b/src/tzString.ts
@@ -18,8 +18,8 @@ export const tzStringAuthenticator = async <D extends DAppClient>(client: D, dom
             });
             return { "Authorization": auth + " " + signature }
         },
-        createOrbit: async (cids: string[]): Promise<HeadersInit> => {
-            const auth = await createTzAuthCreationMessage(pk, pkh, cids, { domain, index: 0 })
+        createOrbit: async (cids: string[], params: { [key: string]: number | string }): Promise<HeadersInit> => {
+            const auth = await createTzAuthCreationMessage(pk, pkh, cids, { domain, index: 0, ...params })
             const { signature } = await client.requestSignPayload({
                 signingType: SigningType.MICHELINE,
                 payload: stringEncoder(auth)

--- a/src/zcap.ts
+++ b/src/zcap.ts
@@ -17,8 +17,8 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
             }
         },
         createOrbit: async (cids: string[], params: { [key: string]: number | string } = {}, method: string = 'did'): Promise<HeadersInit> => {
-            const parameters = method === 'did' ? didVmToParams(client.id(), params) : orbitParams(params);
-            const oid = await makeCid(parameters, 'raw');
+            const parameters = didVmToParams(client.id(), params);
+            const oid = await makeCid(new TextEncoder().encode(parameters));
             const props = invProps(oid, {
                 create: {
                     parameters, content: cids

--- a/src/zcap.ts
+++ b/src/zcap.ts
@@ -1,4 +1,4 @@
-import { Authenticator, Action, getOrbitId, orbitParams } from '.';
+import { Authenticator, Action, makeCid, orbitParams } from '.';
 import { base64url } from 'rfc4648';
 import { Capabilities, W3ID_SECURITY_V2, randomId, Delegation } from '@spruceid/zcap-providers';
 
@@ -16,10 +16,15 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
                 "X-Kepler-Invocation": invstr,
             }
         },
-        createOrbit: async (cids: string[]): Promise<HeadersInit> => {
-            // TODO need orbit id here
-            const props = invProps("orbit_id", { create: cids });
-            const inv = await client.invoke(props, "kepler://orbit_id", randomId(), keplerContext);
+        createOrbit: async (cids: string[], params: { [key: string]: number | string } = {}, method: string = 'did'): Promise<HeadersInit> => {
+            const parameters = method === 'did' ? didVmToParams(client.id(), params) : orbitParams(params);
+            const oid = await makeCid(parameters, 'raw');
+            const props = invProps(oid, {
+                create: {
+                    parameters, content: cids
+                }
+            });
+            const inv = await client.invoke(props, "kepler://" + oid, randomId(), keplerContext);
             const invBytes = new TextEncoder().encode(JSON.stringify(inv));
             return { "X-Kepler-Invocation": base64url.stringify(invBytes) }
         }
@@ -46,10 +51,11 @@ export const startSession = async <C extends Capabilities, S extends Capabilitie
     return await zcapAuthenticator(sessionKey, delegation);
 }
 
-export const didVmToParams = (didVm: string, other: { [key: string]: string } = {}) => {
+export const didVmToParams = (didVm: string, other: { [key: string]: string | number } = {}) => {
     const [did, vm] = didVm.split("#");
-    return "did;did=" + did + orbitParams({ ...other, vm })
+    return "did" + orbitParams({ ...other, did, vm })
 }
+
 
 export const sessionProps = (parentCapability: string, invoker: string, capabilityAction: string[] = ['list', 'get'], expiration: Date) => ({
     parentCapability, invoker, capabilityAction, expiration: expiration.toISOString()
@@ -62,7 +68,7 @@ enum ContentActionKeys {
 }
 
 type CapContentAction = { [K in ContentActionKeys]?: string[] }
-type CapOrbitAction = 'list' | { create: string[] }
+type CapOrbitAction = 'list' | { create: { parameters: string, content: string[] } }
 
 const actionToKey = (action: Action, cids: string[]): CapContentAction | 'list' => {
     switch (action) {

--- a/src/zcap.ts
+++ b/src/zcap.ts
@@ -16,7 +16,7 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
                 "X-Kepler-Invocation": invstr,
             }
         },
-        createOrbit: async (cids: string[], params: { [key: string]: number | string } = {}, method: string = 'did'): Promise<HeadersInit> => {
+        createOrbit: async (cids: string[], params: { [key: string]: number | string } = {}, method: string = 'did'): Promise<{ headers: HeadersInit, oid: string }> => {
             const parameters = didVmToParams(client.id(), params);
             const oid = await makeCid(new TextEncoder().encode(parameters));
             const props = invProps(oid, {
@@ -26,7 +26,7 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
             });
             const inv = await client.invoke(props, "kepler://" + oid, randomId(), keplerContext);
             const invBytes = new TextEncoder().encode(JSON.stringify(inv));
-            return { "X-Kepler-Invocation": base64url.stringify(invBytes) }
+            return { headers: { "X-Kepler-Invocation": base64url.stringify(invBytes) }, oid }
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,6 +308,18 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"
@@ -599,6 +611,26 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz"
@@ -696,6 +728,11 @@
   resolved "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.7.tgz"
   integrity sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg==
 
+"@types/mime-types@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.1.tgz#d9ba43490fa3a3df958759adf69396c3532cf2c1"
+  integrity sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==
+
 "@types/node@*":
   version "15.6.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz"
@@ -705,6 +742,11 @@
   version "11.11.6"
   resolved "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
+"@types/node@^16.11.6":
+  version "16.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
+  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -751,6 +793,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
@@ -760,6 +807,11 @@ acorn@^8.2.4:
   version "8.2.4"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz"
   integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
+
+acorn@^8.4.1:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
 agent-base@6:
   version "6.0.2"
@@ -809,6 +861,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -974,11 +1031,6 @@ blakejs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
-
-blob-polyfill@^4.0.20200601:
-  version "4.0.20200601"
-  resolved "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-4.0.20200601.tgz"
-  integrity sha512-1jB6WOIp6IDxNyng5+9A8g/f0uiphib2ELCN+XAnlssinsW8s1k4VYG9b1TxIUd3pdm9RJSLQuBh6iohYmD4hA==
 
 bn.js@^4.11.9:
   version "4.12.0"
@@ -1295,13 +1347,10 @@ create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-blob@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/cross-blob/-/cross-blob-2.0.0.tgz"
-  integrity sha512-NWzFuyG4GTZnM9MtQvjPYVlO12lZCSBdoHIHCZl9WKShsK3CqO+bEH7nuKwlVomlByb37XvT6nVY5uQxDBmk5Q==
-  dependencies:
-    blob-polyfill "^4.0.20200601"
-    fetch-blob "^2.0.1"
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.1.4:
   version "3.1.4"
@@ -1431,6 +1480,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -1637,9 +1691,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-blob@^2.0.1:
+fetch-blob@^2.1.2:
   version "2.1.2"
-  resolved "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-2.1.2.tgz#a7805db1361bd44c1ef62bb57fb5fe8ea173ef3c"
   integrity sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==
 
 fill-range@^4.0.0:
@@ -2671,7 +2725,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -2741,12 +2795,24 @@ mime-db@1.47.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz"
   integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
 
+mime-db@1.50.0:
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
+  integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
+
 mime-types@^2.1.12:
   version "2.1.30"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz"
   integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
   dependencies:
     mime-db "1.47.0"
+
+mime-types@^2.1.33:
+  version "2.1.33"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
+  integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
+  dependencies:
+    mime-db "1.50.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -3705,6 +3771,24 @@ ts-jest@^26.5.4:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
@@ -3834,6 +3918,11 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
+
+walkdir@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
+  integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
@@ -3982,3 +4071,8 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Implements an interface corrosponding to the HTTP API exposed in [Kepler PR#61](https://github.com/spruceid/kepler/pull/61). Users can:
- get an `S3` client: `const s3 = kepler.s3("myorbitid")`
- upload named objects: `const res = await s3.put("my/content/path.txt", new Blob(...), { "x-my-custom-header": "my metadata entry" })`
- get named objects: `const res = await s3.get("my/content/path.txt")`
- get object metadata: `const res = await s3.head("my/content/path.txt")`
- list s3 contents: `await s3.list()`
- delete contents: `await s3.del("my/content/path.txt")`