### PR TITLE
DID Document based Orbit Manifest and updated URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^26.0.22",
     "@types/mime-types": "^2.1.1",
     "@types/node": "^16.11.6",
-    "ethers": "^5.5.1",
+    "ethers": "^5.6.0",
     "fetch-blob": "^2.1.2",
     "jest": "^26.6.3",
     "jest-localstorage-mock": "^2.4.9",

--- a/src/ethString.ts
+++ b/src/ethString.ts
@@ -1,7 +1,0 @@
-import { Authenticator, Action, getOrbitId, orbitParams } from '.';
-
-const createEthAuthContentMessage = (orbit: string, pkh: string, action: Action, cids: string[], domain: string): string =>
-    `${domain} ${(new Date()).toISOString()} ${pkh} ${orbit} ${action} ${cids.join(' ')}`
-
-const createEthAuthCreationMessage = async (pkh: string, cids: string[], params: { domain: string; salt?: string; index?: number; }): Promise<string> =>
-    `${params.domain} ${(new Date()).toISOString()} ${pkh} ${await getOrbitId("eth", { address: pkh, ...params })} CREATE eth${orbitParams(params)} ${cids.join(' ')}`

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { Kepler, startSession, didVmToParams } from './';
+import { Kepler, startSession, makeOrbitId, siweAuthenticator, startSIWESession } from './';
 import { tz, didkey, Capabilities } from '@spruceid/zcap-providers';
 import * as didkit from '@spruceid/didkit-wasm-node';
 // import { Response } from 'cross-fetch';
@@ -11,6 +11,8 @@ import { b58cencode, prefix } from "@taquito/utils";
 import { randomBytes } from 'crypto';
 import { sessionProps, zcapAuthenticator } from './zcap';
 import { S3 } from './s3';
+import { Signer, Wallet } from 'ethers';
+import { SessionOptions } from './siwe';
 
 const allowlist = 'http://localhost:10000';
 const kepler = ['http://localhost:8000', 'http://localhost:9000'];
@@ -18,24 +20,27 @@ const kepler = ['http://localhost:8000', 'http://localhost:9000'];
 const hostsToString = (h: { [key: string]: string[] }) =>
     Object.keys(h).map(host => `${host}:${h[host].join(",")}`).join("|")
 
-const create = async (did: string, [url, ...urls]: string[], [main, ...rest]: Capabilities[]): Promise<string> => {
-    const hosts = await [url, ...urls].reduce<Promise<{ [k: string]: string[] }>>(async (h, url) => {
-        const hs = await h;
-        const k = new Kepler(url, await zcapAuthenticator(main));
+const create = async (urls: string[], controller: Signer): Promise<string> => {
+    const oid = makeOrbitId(`pkh:eip155:1:${await controller.getAddress()}`, 'default');
+    const a = await siweAuthenticator(oid, controller, 'test.org', '1')
+    const hosts = await Promise.all(urls.map(async (url) => {
+        const k = new Kepler(url, a);
         const id = await k.newPeer();
-        await k.orbit(did).addPeer(id);
-        hs[id] = [await k.idAddr(id)];
-        return hs
-    }, Promise.resolve({}))
+        console.log(await k.createOrbit(oid, id).then(async r => await r.text()))
+    }))
+    return oid
+}
 
-    await Promise.all(urls.map(async url => {
-        const k = new Kepler(url, await zcapAuthenticator(main));
-        k.orbit()
-        console.log(await k.addOrbit([], params, method).then(async r => await r.text()))
-    }));
-
-    const k = new Kepler(url, await zcapAuthenticator(main));
-    return await k.createOrbit([], params, method).then(async r => await r.text());
+const delegate = async (controller: Signer, action: string[], op?: SessionOptions) => {
+    const oid = makeOrbitId(`eip155:1:${await controller.getAddress()}`, 'default');
+    return await didkey(genJWK(), didkit).then(async (dk) => await zcapAuthenticator(
+        dk,
+        await startSIWESession(oid, 'test.org', '1', await controller.getAddress(), dk.id(), action, op).then(async (s) => {
+            const sig = await controller.signMessage(s.toMessage());
+            s.signature = sig;
+            return s
+        })
+    ))
 }
 
 describe('Kepler Client', () => {
@@ -44,17 +49,18 @@ describe('Kepler Client', () => {
     })
 
     it('only allows properly authorized actions', async () => {
-        // create orbit controller
-        const controller = await tz(genTzClient(), didkit);
+        const wallet = Wallet.createRandom();
+        const oid = await create(kepler, wallet);
 
-        const oid = await create(kepler, [controller]);
+        // create orbit controller
+        const controller = await siweAuthenticator(oid, wallet, 'test.org', '1');
 
         // create session key
         const sessionKey = await didkey(genJWK(), didkit);
 
         // get authenticator for client
-        const write = new Kepler(kepler[0], await startSession(oid, controller, sessionKey, ['put', 'del'])).orbit(oid);
-        const read = new Kepler(kepler[0], await startSession(oid, controller, sessionKey, ['get', 'list'])).orbit(oid);
+        const write = new Kepler(kepler[0], await delegate(wallet, ['put', 'del'])).orbit(oid);
+        const read = new Kepler(kepler[0], await delegate(wallet, ['get', 'list'])).orbit(oid);
 
         const json = { hello: 'hey' };
         const json2 = { hello: 'hey2' };
@@ -86,13 +92,14 @@ describe('Kepler Client', () => {
     })
 
     it('replicates in s3', async () => {
+        const wallet = Wallet.createRandom();
+        const oid = await create(kepler, wallet);
+
         // create orbit controller
-        const controller = await tz(genTzClient(), didkit);
+        const controller = await siweAuthenticator(oid, wallet, 'test.org', '1');
 
-        const oid = await create(kepler, [controller]);
-
-        const node1 = new S3(kepler[0], oid, await zcapAuthenticator(controller));
-        const node2 = new S3(kepler[1], oid, await zcapAuthenticator(controller));
+        const node1 = new S3(kepler[0], oid, controller);
+        const node2 = new S3(kepler[1], oid, controller);
 
         await new Promise(res => setTimeout(res, 4000));
         const json = { hello: "there" };
@@ -115,45 +122,30 @@ describe('Kepler Client', () => {
     }, 60000)
 
     it('doesnt allow expired authorizations', async () => {
+        const wallet = Wallet.createRandom();
+        const oid = await create(kepler, wallet);
+        //
         // create orbit controller
-        const controller = await tz(genTzClient(), didkit);
-
-        const oid = await create(kepler, [controller]);
-
-        // create session key
-        const sessionKey = await didkey(genJWK(), didkit);
+        const controller = await siweAuthenticator(oid, wallet, 'test.org', '1');
 
         // get expired authenticator for client
-        const keplerClient = new Kepler(kepler[0], await startSession(oid, controller, sessionKey, ['list'], 0)).orbit(oid);
+        const keplerClient = new Kepler(kepler[0], await delegate(wallet, ['list'], { exp: new Date(Date.now() - 10) })).orbit(oid);
         await expect(keplerClient.list()).resolves.toHaveProperty('status', 401);
     })
 
     it('only allows authorized invokers', async () => {
+        const wallet = Wallet.createRandom();
+        const oid = await create(kepler, wallet);
+
         // create orbit controller
-        const controller = await tz(genTzClient(), didkit);
+        const controller = await siweAuthenticator(oid, wallet, 'test.org', '1');
 
-        const oid = await create(kepler, [controller]);
-
-        // create session key
-        const sessionKey = await didkey(genJWK(), didkit);
-
-        const authd = new Kepler(kepler[0], await startSession(oid, controller, sessionKey)).orbit(oid);
+        const authd = new Kepler(kepler[0], await delegate(wallet, ['list'])).orbit(oid);
         const unauthd = [
-            // incorrect invoker
-            await zcapAuthenticator(
-                await didkey(genJWK(), didkit),
-                await controller.delegate(sessionProps(
-                    "kepler://" + oid,
-                    // id will not match randomly generated did:key
-                    sessionKey.id(),
-                    ['list'],
-                    new Date(Date.now() + 1000 * 60)
-                ), [])
-            ),
             // no delegation
             await zcapAuthenticator(await didkey(genJWK(), didkit)),
             // expired delegation
-            await startSession(oid, controller, sessionKey, ['list'], 0),
+            await delegate(wallet, ['list'], { exp: new Date(Date.now() - 10) }),
         ].map(a => new Kepler(kepler[0], a).orbit(oid));
 
         await expect(authd.list()).resolves.toHaveProperty('status', 200);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import CID from 'cids';
 import multihashing from 'multihashing-async';
 import { Ipfs } from './ipfs';
 import { S3 } from './s3';
-export { makeKRI, getKRI } from './util';
+export { makeKRI, getKRI, makeOrbitId } from './util';
 export { zcapAuthenticator, startSession } from './zcap';
 export { tzStringAuthenticator } from './tzString';
 export { siweAuthenticator, startSIWESession } from './siwe';
@@ -47,11 +47,11 @@ export class Kepler {
         return new Ipfs(this.url, orbit, this.auth);
     }
 
-    public async new_id(): Promise<string> {
+    public async newPeer(): Promise<string> {
         return await fetch(this.url + "/peer/generate").then(async res => await res.text());
     }
 
-    public async id_addr(id: string): Promise<string> {
+    public async idAddr(id: string): Promise<string> {
         return await fetch(this.url + "/peer/relay").then(async res => await res.text() + "/p2p-circuit/p2p/" + id);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export enum Action {
 }
 
 export interface Authenticator {
-    content: (orbit: string, cids: string[], action: Action) => Promise<HeadersInit>;
+    content: (orbit: string, service: string, path: string, fragment: string) => Promise<HeadersInit>;
     authorizePeer: (orbit: string, peer: string) => Promise<HeadersInit>;
 };
 

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -16,13 +16,13 @@ export class Ipfs {
         const oidCid = await makeCidString(this.orbitId);
         return await fetch(makeContentPath(this.url, oidCid, cid), {
             method: "GET",
-            headers: authenticate ? { ...await this.auth.content(this.orbit, [cid], Action.get) } : undefined
+            headers: authenticate ? { ...await this.auth.content(this.orbit, 'ipfs', cid, 'get') } : undefined
         })
     }
 
     public async put(first: Blob, ...rest: Blob[]): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(new Uint8Array(await c.arrayBuffer())))), Action.put)
+        const auth = await this.auth.content(this.orbit, 'ipfs', '', 'put')
         if (rest.length >= 1) {
             return await fetch(makeOrbitPath(this.url, oidCid), {
                 method: "PUT",
@@ -43,13 +43,16 @@ export class Ipfs {
         const oidCid = await makeCidString(this.orbitId);
         return await fetch(makeContentPath(this.url, oidCid, cid), {
             method: 'DELETE',
-            headers: await this.auth.content(this.orbit, [cid], Action.delete)
+            headers: await this.auth.content(this.orbit, 'ipfs', cid, 'del')
         })
     }
 
     public async list(): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        return await fetch(makeOrbitPath(this.url, oidCid), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+        return await fetch(makeOrbitPath(this.url, oidCid), {
+            method: 'GET',
+            headers: await this.auth.content(this.orbit, 'ipfs', '', 'list')
+        })
     }
 }
 

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -1,4 +1,4 @@
-import { Action, Authenticator, makeCid } from "./index";
+import { Action, Authenticator, makeCid, makeCidString } from "./index";
 import fetch from 'cross-fetch';
 
 export class Ipfs {
@@ -13,23 +13,25 @@ export class Ipfs {
     }
 
     public async get(cid: string, authenticate: boolean = true): Promise<Response> {
-        return await fetch(makeContentPath(this.url, this.orbit, cid), {
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeContentPath(this.url, oidCid, cid), {
             method: "GET",
             headers: authenticate ? { ...await this.auth.content(this.orbit, [cid], Action.get) } : undefined
         })
     }
 
     public async put(first: Blob, ...rest: Blob[]): Promise<Response> {
+        const oidCid = await makeCidString(this.orbitId);
         const auth = await this.auth.content(this.orbit, await Promise.all([first, ...rest].map(async (c) => await makeCid(new Uint8Array(await c.arrayBuffer())))), Action.put)
         if (rest.length >= 1) {
-            return await fetch(makeOrbitPath(this.url, this.orbit), {
+            return await fetch(makeOrbitPath(this.url, oidCid), {
                 method: "PUT",
                 // @ts-ignore
                 body: await makeFormRequest(first, ...rest),
                 headers: auth
             })
         } else {
-            return await fetch(makeOrbitPath(this.url, this.orbit), {
+            return await fetch(makeOrbitPath(this.url, oidCid), {
                 method: "PUT",
                 body: first,
                 headers: { ...auth, ...{ "Content-Type": "application/json" } }
@@ -38,14 +40,16 @@ export class Ipfs {
     }
 
     public async del(cid: string): Promise<Response> {
-        return await fetch(makeContentPath(this.url, this.orbit, cid), {
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeContentPath(this.url, oidCid, cid), {
             method: 'DELETE',
             headers: await this.auth.content(this.orbit, [cid], Action.delete)
         })
     }
 
     public async list(): Promise<Response> {
-        return await fetch(makeOrbitPath(this.url, this.orbit), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeOrbitPath(this.url, oidCid), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
     }
 }
 

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -14,24 +14,24 @@ export class S3 {
 
     public async get(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        return await fetch(makeContentPath(this.url, oidCid, key, version), {
+        return await fetch(makeContentPath(this.url, oidCid, key), {
             method: "GET",
-            headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
+            headers: authenticate ? { ...await this.auth.content(this.orbit, 's3', key, 'get') } : undefined
         })
     }
 
     public async head(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        return await fetch(makeContentPath(this.url, oidCid, key, version), {
+        return await fetch(makeContentPath(this.url, oidCid, key), {
             method: "HEAD",
-            headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
+            headers: authenticate ? { ...await this.auth.content(this.orbit, 's3', key, 'metadata') } : undefined
         })
     }
 
     public async put(key: string, value: Blob, metadata: { [key: string]: string }): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
         const cid = await makeCid(new Uint8Array(await value.arrayBuffer()));
-        const auth = await this.auth.content(this.orbit, [cid], Action.put)
+        const auth = await this.auth.content(this.orbit, 's3', key, 'put')
         return await fetch(makeContentPath(this.url, oidCid, key), {
             method: "PUT",
             body: value,
@@ -39,17 +39,20 @@ export class S3 {
         })
     }
 
-    public async del(cid: string, version?: string): Promise<Response> {
+    public async del(key: string, version?: string): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        return await fetch(makeContentPath(this.url, oidCid, cid, version), {
+        return await fetch(makeContentPath(this.url, oidCid, key, version), {
             method: 'DELETE',
-            headers: await this.auth.content(this.orbit, [cid], Action.delete)
+            headers: await this.auth.content(this.orbit, 's3', key, 'del')
         })
     }
 
-    public async list(): Promise<Response> {
+    public async list(prefix: string = ''): Promise<Response> {
         const oidCid = await makeCidString(this.orbitId);
-        return await fetch(makeOrbitPath(this.url, oidCid), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+        return await fetch(makeOrbitPath(this.url, oidCid), {
+            method: 'GET',
+            headers: await this.auth.content(this.orbit, 's3', prefix, 'list')
+        })
     }
 }
 

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,4 +1,4 @@
-import { Action, Authenticator, makeCid } from "./index";
+import { Action, Authenticator, makeCid, makeCidString } from "./index";
 import fetch from 'cross-fetch';
 
 export class S3 {
@@ -13,23 +13,26 @@ export class S3 {
     }
 
     public async get(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
-        return await fetch(makeContentPath(this.url, this.orbit, key, version), {
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeContentPath(this.url, oidCid, key, version), {
             method: "GET",
             headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
         })
     }
 
     public async head(key: string, authenticate: boolean = true, version?: string): Promise<Response> {
-        return await fetch(makeContentPath(this.url, this.orbit, key, version), {
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeContentPath(this.url, oidCid, key, version), {
             method: "HEAD",
             headers: authenticate ? { ...await this.auth.content(this.orbit, [key], Action.get) } : undefined
         })
     }
 
     public async put(key: string, value: Blob, metadata: { [key: string]: string }): Promise<Response> {
+        const oidCid = await makeCidString(this.orbitId);
         const cid = await makeCid(new Uint8Array(await value.arrayBuffer()));
         const auth = await this.auth.content(this.orbit, [cid], Action.put)
-        return await fetch(makeContentPath(this.url, this.orbit, key), {
+        return await fetch(makeContentPath(this.url, oidCid, key), {
             method: "PUT",
             body: value,
             headers: { ...auth, ...metadata }
@@ -37,14 +40,16 @@ export class S3 {
     }
 
     public async del(cid: string, version?: string): Promise<Response> {
-        return await fetch(makeContentPath(this.url, this.orbit, cid, version), {
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeContentPath(this.url, oidCid, cid, version), {
             method: 'DELETE',
             headers: await this.auth.content(this.orbit, [cid], Action.delete)
         })
     }
 
     public async list(): Promise<Response> {
-        return await fetch(makeOrbitPath(this.url, this.orbit), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
+        const oidCid = await makeCidString(this.orbitId);
+        return await fetch(makeOrbitPath(this.url, oidCid), { method: 'GET', headers: await this.auth.content(this.orbit, [], Action.list) })
     }
 }
 

--- a/src/siwe.ts
+++ b/src/siwe.ts
@@ -54,10 +54,10 @@ const createSiweAuthCreationMessage = (
         issuedAt: opts.nbf?.toISOString() ?? new Date().toISOString(),
         expirationTime: opts.exp?.toISOString() ?? new Date(Date.now() + 120000).toISOString(),
         resources: [`${orbit}#peer`],
-        uri: peer
+        uri: `peer:${peer}`
     }).toMessage()
 
-type SessionOptions = {
+export type SessionOptions = {
     nbf?: Date,
     exp?: Date
 };

--- a/src/siwe.ts
+++ b/src/siwe.ts
@@ -1,28 +1,28 @@
 import { SiweMessage } from 'siwe';
 import { Signer } from 'ethers';
 import { base64url } from 'rfc4648';
-import { Authenticator, Action, getOrbitId, orbitParams } from '.';
+import { Authenticator, Action, getOrbitId, orbitParams, makeKRI } from '.';
 import { Delegation } from '@spruceid/zcap-providers';
 import { getHeaderAndDelId } from './zcap';
 
 const invHeaderStr = "x-siwe-invocation";
 
-export const siweAuthenticator = async <S extends Signer, D>(client: S, domain: string, chainId: string = '1', delegation?: Delegation<D> | SiweMessage): Promise<Authenticator> => {
+export const siweAuthenticator = async <S extends Signer, D>(orbit: string, client: S, domain: string, chainId: string = '1', delegation?: Delegation<D> | SiweMessage): Promise<Authenticator> => {
     const pkh = await client.getAddress();
     const { h, delId } = getHeaderAndDelId(delegation);
 
     return {
         content: async (orbit: string, cids: string[], action: Action): Promise<HeadersInit> => {
-            const auth = createSiweAuthContentMessage(orbit, pkh, action, cids, domain, chainId);
+            const auth = createSiweAuthContentMessage(orbit, pkh, action, cids, domain, chainId, delId);
             const signature = await client.signMessage(auth);
             const invstr = base64url.stringify(new TextEncoder().encode(JSON.stringify([auth, signature])));
             return { [invHeaderStr]: invstr, ...h } as {}
         },
-        createOrbit: async (cids: string[], params: { [key: string]: number | string }): Promise<{ headers: HeadersInit, oid: string }> => {
-            const { oid, auth } = await createSiweAuthCreationMessage(pkh, cids, domain, params, chainId)
+        authorizePeer: async (orbit: string, peer: string): Promise<HeadersInit> => {
+            const auth = createSiweAuthCreationMessage(orbit, pkh, peer, domain, chainId)
             const signature = await client.signMessage(auth);
             const invstr = base64url.stringify(new TextEncoder().encode(JSON.stringify([auth, signature])));
-            return { headers: { [invHeaderStr]: invstr }, oid }
+            return { [invHeaderStr]: invstr }
         }
     }
 }
@@ -30,31 +30,33 @@ export const siweAuthenticator = async <S extends Signer, D>(client: S, domain: 
 const statement = "Authorize an action on your Kepler Orbit";
 const version = "1";
 
-const createSiweAuthContentMessage = (orbit: string, address: string, action: Action, cids: string[], domain: string, chainId: string) => {
+const createSiweAuthContentMessage = (orbit: string, address: string, action: Action, paths: string[], domain: string, chainId: string, del?: string) => {
     const now = Date.now();
     return new SiweMessage({
         domain, address, statement, version, chainId,
         issuedAt: new Date(now).toISOString(),
         expirationTime: new Date(now + 10000).toISOString(),
-        resources: cids.map(cid => `kepler://${orbit}/${cid}#${action.toLowerCase()}`),
-        uri: `kepler://${orbit}`
+        resources: paths.map(path => getKRI(orbit, path, action.toLowerCase())),
+        uri: del ? `urn:siwe:kepler:{del}` : orbit
     }).toMessage()
 }
 
-const createSiweAuthCreationMessage = async (address: string, cids: string[], domain: string, params: { [key: string]: number | string }, chainId: string) => {
-    const now = Date.now();
-    const paramsStr = orbitParams({ did: `did:pkh:eip155:${chainId}:${address}`, vm: "blockchainAccountId", ...params });
-    const oid = await getOrbitId("did", paramsStr);
-    const auth = new SiweMessage({
+const createSiweAuthCreationMessage = (
+    did: string,
+    name: string,
+    address: string,
+    peer: string,
+    domain: string,
+    chainId: string,
+    opts: SessionOptions = { nbf: new Date(), exp: new Date(Date.now() + 120000) }
+) => new SiweMessage({
         domain, address, version, chainId,
         statement: 'Authorize this provider to host your Orbit',
-        issuedAt: new Date(now).toISOString(),
-        expirationTime: new Date(now + 10000).toISOString(),
-        resources: [`kepler://${oid}#host`, ...cids.map(cid => `kepler://${oid}/${cid}#put`)],
-        uri: `kepler://did${paramsStr}`
-    }).toMessage();
-    return { oid, auth }
-}
+        issuedAt: opts.nbf || new Date().toISOString(),
+        expirationTime: opts.exp || new Date(Date.now() + 120000).toISOString(),
+        resources: [make],
+    uri: peer
+    }).toMessage()
 
 type SessionOptions = {
     nbf?: Date,

--- a/src/tzString.ts
+++ b/src/tzString.ts
@@ -1,5 +1,5 @@
 import { DAppClient, SigningType } from '@airgap/beacon-sdk';
-import { Authenticator, Action, getOrbitId, orbitParams } from '.';
+import { Authenticator, Action, makeCid, makeKRI } from '.';
 
 export const tzStringAuthenticator = async <D extends DAppClient>(client: D, domain: string): Promise<Authenticator> => {
     const { publicKey: pk, address: pkh } = await client.getActiveAccount().then(acc => {
@@ -18,13 +18,13 @@ export const tzStringAuthenticator = async <D extends DAppClient>(client: D, dom
             });
             return { "Authorization": auth + " " + signature }
         },
-        createOrbit: async (cids: string[], params: { [key: string]: number | string }): Promise<{ headers: HeadersInit, oid: string }> => {
-            const { oid, auth } = await createTzAuthCreationMessage(pk, pkh, cids, { domain, index: 0, ...params })
+        authorizePeer: async (orbit: string, peer: string): Promise<HeadersInit> => {
+            const auth = await createTzAuthCreationMessage(orbit, pk, pkh, domain, peer)
             const { signature } = await client.requestSignPayload({
                 signingType: SigningType.MICHELINE,
                 payload: stringEncoder(auth)
             });
-            return { headers: { "Authorization": auth + " " + signature }, oid }
+            return { "Authorization": auth + " " + signature }
         }
     }
 }
@@ -32,8 +32,8 @@ export const tzStringAuthenticator = async <D extends DAppClient>(client: D, dom
 const createTzAuthContentMessage = (orbit: string, pk: string, pkh: string, action: Action, cids: string[], domain: string): string =>
     `Tezos Signed Message: ${domain} ${(new Date()).toISOString()} ${pk} ${pkh} ${orbit} ${action} ${cids.join(' ')}`
 
-const createTzAuthCreationMessage = async (pk: string, pkh: string, cids: string[], params: { domain: string; salt?: string; index?: number; }): Promise<{ auth: string, oid: string }> => await getOrbitId("tz", { address: pkh, ...params }).then(oid =>
-    ({ oid, auth: `Tezos Signed Message: ${params.domain} ${(new Date()).toISOString()} ${pk} ${pkh} ${oid} CREATE tz${orbitParams(params)} ${cids.join(' ')}` }))
+const createTzAuthCreationMessage = async (orbit: string, pk: string, pkh: string, domain: string, peer: string): Promise<string> =>
+    `Tezos Signed Message: ${domain} ${(new Date()).toISOString()} ${pk} ${pkh} ${orbit} CREATE ${peer}`
 
 export const stringEncoder = (s: string): string => {
     const bytes = Buffer.from(s, 'utf8');

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,8 @@
+
+
+const makeKRI = (suffix: string, name: string, app?: string, path?: string, fragment?: string) =>
+    `kepler:${suffix}://${name}${app ? ':' + app : ''}${path ? '/' + path : ''}${fragment ? '#' + fragment : ''}`
+
+const makeOrbitId = (suffix: string, name: string) => `kepler:${suffix}://${name}`
+
+const getKRI = (orbit: string, app: string, path: string, fragment?: string) => `${orbit}:${app}/${path}${fragment ? '#' + fragment : ''}`

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,10 @@
 
 
-const makeKRI = (suffix: string, name: string, app?: string, path?: string, fragment?: string) =>
-    `kepler:${suffix}://${name}${app ? ':' + app : ''}${path ? '/' + path : ''}${fragment ? '#' + fragment : ''}`
+export const makeKRI = (suffix: string, name: string, app?: string, path?: string, fragment?: string) =>
+    `kepler:${suffix}://${name}${app ? '/' + app : ''}${path ? '/' + path : ''}${fragment ? '#' + fragment : ''}`
 
-const makeOrbitId = (suffix: string, name: string) => `kepler:${suffix}://${name}`
+export const makeOrbitId = (suffix: string, name: string) => `kepler:${suffix}://${name}`
 
-const getKRI = (orbit: string, app: string, path: string, fragment?: string) => `${orbit}:${app}/${path}${fragment ? '#' + fragment : ''}`
+export const getKRI = (orbit: string, app: string, path: string, fragment?: string) => `${orbit}/${app}/${path}${fragment ? '#' + fragment : ''}`
+
+export const didToOrbitId = (did: string, name: string) => did.startsWith('did:') ? makeOrbitId(did.slice(4), name) : makeOrbitId(did, name)

--- a/src/zcap.ts
+++ b/src/zcap.ts
@@ -19,7 +19,7 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
     return {
         content: async (orbit: string, cids: string[], action: Action): Promise<HeadersInit> => {
             const props = invProps(orbit, actionToKey(action, cids));
-            const inv = await client.invoke(props, delId || ("kepler://" + orbit), randomId(), keplerContext);
+            const inv = await client.invoke(props, delId || orbit, randomId(), keplerContext);
             const invstr = base64url.stringify(new TextEncoder().encode(JSON.stringify(inv)));
             return {
                 [invHeaderStr]: invstr,
@@ -30,9 +30,9 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
             const props = {
                 invocationTarget: orbit,
             };
-            const inv = await client.invoke(props, "kepler://" + oid, randomId(), keplerContext);
+            const inv = await client.invoke(props, orbit, randomId(), keplerContext);
             const invBytes = new TextEncoder().encode(JSON.stringify(inv));
-            return { headers: { [invHeaderStr]: base64url.stringify(invBytes) }, oid }
+            return { [invHeaderStr]: base64url.stringify(invBytes) }
         }
     }
 }
@@ -56,12 +56,6 @@ export const startSession = async <C extends Capabilities, S extends Capabilitie
     // return authenticator for client
     return await zcapAuthenticator(sessionKey, delegation);
 }
-
-export const didVmToParams = (didVm: string, other: { [key: string]: string | number } = {}) => {
-    const [did, vm] = didVm.split("#");
-    return "did" + orbitParams({ ...other, did, vm })
-}
-
 
 export const sessionProps = (parentCapability: string, invoker: string, capabilityAction: string[] = ['list', 'get'], expiration: Date) => ({
     parentCapability, invoker, capabilityAction, expiration: expiration.toISOString()

--- a/src/zcap.ts
+++ b/src/zcap.ts
@@ -1,4 +1,4 @@
-import { Authenticator, Action, makeCid, orbitParams } from '.';
+import { Authenticator, Action, makeCid, makeKRI } from '.';
 import { base64url } from 'rfc4648';
 import { Capabilities, W3ID_SECURITY_V2, randomId, Delegation } from '@spruceid/zcap-providers';
 import { SiweMessage } from 'siwe';
@@ -26,14 +26,10 @@ export const zcapAuthenticator = async <C extends Capabilities, D>(client: C, de
                 ...h
             } as {}
         },
-        createOrbit: async (cids: string[], params: { [key: string]: number | string } = {}, method: string = 'did'): Promise<{ headers: HeadersInit, oid: string }> => {
-            const parameters = didVmToParams(client.id(), params);
-            const oid = await makeCid(new TextEncoder().encode(parameters));
-            const props = invProps(oid, {
-                create: {
-                    parameters, content: cids
-                }
-            });
+        authorizePeer: async (orbit: string, peer: string): Promise<HeadersInit> => {
+            const props = {
+                invocationTarget: orbit,
+            };
             const inv = await client.invoke(props, "kepler://" + oid, randomId(), keplerContext);
             const invBytes = new TextEncoder().encode(JSON.stringify(inv));
             return { headers: { [invHeaderStr]: base64url.stringify(invBytes) }, oid }

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,6 +335,21 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/abi@5.6.0", "@ethersproject/abi@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.0.tgz#ea07cbc1eec2374d32485679c12408005895e9f3"
+  integrity sha512-AhVByTwdXCc2YQ20v300w6KVHle9g2OFc28ZAFCPnJyEpkv1xKXjZcSTgWOlv1i+0dqlgF8RCF2Rn2KC1t+1Vg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
@@ -348,6 +363,19 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/web" "^5.5.0"
 
+"@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+
 "@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
@@ -358,6 +386,17 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
 
 "@ethersproject/address@5.5.0", "@ethersproject/address@^5.5.0":
   version "5.5.0"
@@ -370,12 +409,30 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
 
+"@ethersproject/address@5.6.0", "@ethersproject/address@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+
 "@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
   integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
+
+"@ethersproject/base64@5.6.0", "@ethersproject/base64@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
 
 "@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
   version "5.5.0"
@@ -384,6 +441,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/basex@5.6.0", "@ethersproject/basex@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.0.tgz#9ea7209bf0a1c3ddc2a90f180c3a7f0d7d2e8a69"
+  integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
 
 "@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.5.0":
   version "5.5.0"
@@ -394,6 +459,15 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@5.6.0", "@ethersproject/bignumber@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bytes@5.5.0", "@ethersproject/bytes@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
@@ -401,12 +475,26 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/bytes@5.6.0", "@ethersproject/bytes@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.0.tgz#81652f2a0e04533575befadce555213c11d8aa20"
+  integrity sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/constants@5.5.0", "@ethersproject/constants@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/constants@5.6.0", "@ethersproject/constants@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
 
 "@ethersproject/contracts@5.5.0":
   version "5.5.0"
@@ -424,6 +512,22 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
 
+"@ethersproject/contracts@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
+  integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
+  dependencies:
+    "@ethersproject/abi" "^5.6.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+
 "@ethersproject/hash@5.5.0", "@ethersproject/hash@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
@@ -437,6 +541,20 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
   version "5.5.0"
@@ -455,6 +573,24 @@
     "@ethersproject/strings" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/wordlists" "^5.5.0"
+
+"@ethersproject/hdnode@5.6.0", "@ethersproject/hdnode@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.0.tgz#9dcbe8d629bbbcf144f2cae476337fe92d320998"
+  integrity sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
 
 "@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
   version "5.5.0"
@@ -475,6 +611,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@5.6.0", "@ethersproject/json-wallets@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz#4c2fc27f17e36c583e7a252fb938bc46f98891e5"
+  integrity sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
@@ -483,10 +638,23 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@5.6.0", "@ethersproject/keccak256@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.5.0", "@ethersproject/logger@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
 
 "@ethersproject/networks@5.5.0", "@ethersproject/networks@^5.5.0":
   version "5.5.0"
@@ -494,6 +662,13 @@
   integrity sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/networks@5.6.0", "@ethersproject/networks@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.0.tgz#486d03fff29b4b6b5414d47a232ded09fe10de5e"
+  integrity sha512-DaVzgyThzHgSDLuURhvkp4oviGoGe9iTZW4jMEORHDRCgSZ9K9THGFKqL+qGXqPAYLEgZTf5z2w56mRrPR1MjQ==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
   version "5.5.0"
@@ -503,12 +678,27 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/sha2" "^5.5.0"
 
+"@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
+  integrity sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+
 "@ethersproject/properties@5.5.0", "@ethersproject/properties@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
   integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/providers@5.5.0":
   version "5.5.0"
@@ -535,6 +725,31 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.0.tgz#08ec8e2666771e3a347e66c8f664a2af97366534"
+  integrity sha512-6+5PKXTWAttJWFWF8+xCDTCa2/dtq9BNrdKQHGl0IyIOwj99vM6OeThmIRcsIAzIOb8m0XS6w+1KFZwrf3j9nw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.5.0", "@ethersproject/random@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.0.tgz#305ed9e033ca537735365ac12eed88580b0f81f9"
@@ -543,6 +758,14 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/random@5.6.0", "@ethersproject/random@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
+  integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
@@ -550,6 +773,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/rlp@5.6.0", "@ethersproject/rlp@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
@@ -560,6 +791,15 @@
     "@ethersproject/logger" "^5.5.0"
     hash.js "1.1.7"
 
+"@ethersproject/sha2@5.6.0", "@ethersproject/sha2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
 "@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
@@ -568,6 +808,18 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.6.0", "@ethersproject/signing-key@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.0.tgz#4f02e3fb09e22b71e2e1d6dc4bcb5dafa69ce042"
+  integrity sha512-S+njkhowmLeUu/r7ir8n78OUKx63kBdMCPssePS89So1TH4hZqnWFsThEd/GiXYp9qMxVrydf7KdM9MTGPFukA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
     elliptic "6.5.4"
     hash.js "1.1.7"
@@ -584,6 +836,18 @@
     "@ethersproject/sha2" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/solidity@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.0.tgz#64657362a596bf7f5630bdc921c07dd78df06dc3"
+  integrity sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/strings@5.5.0", "@ethersproject/strings@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
@@ -592,6 +856,15 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/strings@5.6.0", "@ethersproject/strings@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.5.0":
   version "5.5.0"
@@ -608,6 +881,21 @@
     "@ethersproject/rlp" "^5.5.0"
     "@ethersproject/signing-key" "^5.5.0"
 
+"@ethersproject/transactions@5.6.0", "@ethersproject/transactions@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+
 "@ethersproject/units@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
@@ -616,6 +904,15 @@
     "@ethersproject/bignumber" "^5.5.0"
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/units@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
+  integrity sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/wallet@5.5.0":
   version "5.5.0"
@@ -638,6 +935,27 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/wordlists" "^5.5.0"
 
+"@ethersproject/wallet@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.0.tgz#33d11a806d783864208f348709a5a3badac8e22a"
+  integrity sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/json-wallets" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
 "@ethersproject/web@5.5.0", "@ethersproject/web@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.0.tgz#0e5bb21a2b58fb4960a705bfc6522a6acf461e28"
@@ -649,6 +967,17 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/web@5.6.0", "@ethersproject/web@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
+  dependencies:
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
@@ -659,6 +988,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/wordlists@5.6.0", "@ethersproject/wordlists@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
+  integrity sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1997,6 +2337,42 @@ ethers@^5.5.1:
     "@ethersproject/wallet" "5.5.0"
     "@ethersproject/web" "5.5.0"
     "@ethersproject/wordlists" "5.5.0"
+
+ethers@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.0.tgz#924eb965dc03963fad0a09ce687efdf49aca3b45"
+  integrity sha512-00FP71jt6bW3ndO5DhgH9mLIZhoCGnAKFLu8qig5KmV03ubEChKf2ilB3g6fX512tTYo+tSMDJ5WpCJWdBHkBQ==
+  dependencies:
+    "@ethersproject/abi" "5.6.0"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.0"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.0"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.0"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.0"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
 
 exec-sh@^0.3.2:
   version "0.3.6"


### PR DESCRIPTION
Updates the action, orbit and resource ID representations used in the authorisation tokens. This corresponds to [Kepler PR #83](https://github.com/spruceid/kepler/pull/83). Specifically:
- changes `Authenticator` function params to be simpler and match new URI model
- makes orbit ID generation deterministic and user-decidable
- re-organises the ZCAP-LD invocations to have one target and action, with delegations having a list of resources