### PR TITLE
Separate concerns of orbit connection vs hosting.

### DIFF
--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -24,13 +24,18 @@ let loadOrbit = document.getElementById("loadOrbit") as HTMLDivElement;
 let loadOrbitBtn = document.getElementById("loadOrbitBtn") as HTMLButtonElement;
 
 loadOrbitBtn.onclick = async () => {
-  kepler = new Kepler(wallet, { hosts: ["http://localhost:8000"] });
-  let o = await kepler.orbit();
-  if (o === undefined) {
+  kepler = new Kepler(wallet, { host: "http://localhost:8000" });
+  orbitConnection = await kepler.connect();
+
+  let ok = await orbitConnection
+    .list()
+    .then(
+      async ({ status }) => status !== 404 || (await kepler.hostOrbit()).ok
+    );
+  if (!ok) {
     console.error("unable to host orbit");
     return;
   }
-  orbitConnection = o;
 
   loadOrbitBtn.innerText = orbitConnection.id();
   loadOrbitBtn.disabled = true;

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -4,6 +4,10 @@ import { invoke } from "./kepler";
 export class KV {
   constructor(private url: string, private auth: Authenticator) {}
 
+  public reconnect(newUrl: string) {
+    this.url = newUrl;
+  }
+
   public async get(key: string): Promise<Response> {
     return await this.invoke({
       headers: await this.auth.invocationHeaders("get", key),


### PR DESCRIPTION
Make it possible for devs to handle missing orbits themselves. This also simplifies the signature of `kepler.connect()` (previously `kepler.orbit()`).