### PR TITLE
allow for passing of additional headers in kv.put requests

### DIFF
--- a/wrapper/src/orbit.ts
+++ b/wrapper/src/orbit.ts
@@ -49,7 +49,7 @@ export class OrbitConnection {
    *
    * @param key The key with which the object is indexed.
    * @param value The value to be stored.
-   * @param req Optional request parameters.
+   * @param req Optional request parameters. Request Headers can be passed via the `headers` property.
    * @returns A {@link Response} without the `data` property.
    */
   async put(key: string, value: any, req?: Request): Promise<Response> {
@@ -77,8 +77,7 @@ export class OrbitConnection {
       );
     }
 
-    // @ts-ignore
-    return this.kv.put(key, blob, {}).then(transformResponse);
+    return this.kv.put(key, blob, req?.headers || {}).then(transformResponse);
   }
 
   /** Retrieve an object from the connected orbit.
@@ -232,6 +231,8 @@ export class OrbitConnection {
 export type Request = {
   /** Request to receive the data as a {@link https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream | ReadableStream}. */
   streamBody?: boolean;
+  /** Add additional entries to the request HTTP Headers. */
+  headers?: { [key: string]: string };
 };
 
 /** Response from kepler requests.


### PR DESCRIPTION
currently there is no way to pass custom headers for writing metadata without using the `KV` class directly. This pr adds `.headers` to the `Request` param object for that purpose. So far these are only applied when calling `Orbit.put`, not in `get` or `list` etc.