### PR TITLE
add reexports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
   Session,
   SessionConfig,
   activateSession,
-  hostOrbit
+  hostOrbit,
 } from "@spruceid/kepler-sdk-wrapper";
 import {
   Kepler as Kepler_,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ export {
   HostConfig,
   Session,
   SessionConfig,
-  activateSession
+  activateSession,
+  hostOrbit
 } from "@spruceid/kepler-sdk-wrapper";
 import {
   Kepler as Kepler_,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
   HostConfig,
   Session,
   SessionConfig,
+  activateSession
 } from "@spruceid/kepler-sdk-wrapper";
 import {
   Kepler as Kepler_,

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -1,5 +1,5 @@
 export { Kepler, KeplerOptions } from "./kepler";
-export { OrbitConnection, Request, Response } from "./orbit";
+export { OrbitConnection, Request, Response, hostOrbit } from "./orbit";
 export { Bytes, WalletProvider } from "./walletProvider";
 export { HostConfig, Session, SessionConfig } from "../../wasm";
 export { activateSession } from "./authenticator";

--- a/wrapper/src/index.ts
+++ b/wrapper/src/index.ts
@@ -2,3 +2,4 @@ export { Kepler, KeplerOptions } from "./kepler";
 export { OrbitConnection, Request, Response } from "./orbit";
 export { Bytes, WalletProvider } from "./walletProvider";
 export { HostConfig, Session, SessionConfig } from "../../wasm";
+export { activateSession } from "./authenticator";


### PR DESCRIPTION
This PR adds some useful re-exports to enable integration with apps which will be responsible for generating their own authorisation/SIWE messages. These are:
- `hostOrbit`: for initialising an orbit on a remote host
- `activateSession`: for initialising a session bound to a keypair