### PR TITLE
delete all at prefix

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -387,11 +387,10 @@ describe("Kepler Client", () => {
 
   it("can delete all contents", async () => {
     let rs = await orbit.deleteAll();
-    for r in rs {
-      expect(r).toEqual({ success: true });
+    for (const r in rs) {
+      expect(rs[r].ok).toEqual(true);
     }
-    let list = orbit.list();
+    let list = await orbit.list();
     expect(list.data).toHaveLength(0);
   });
-
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -384,4 +384,14 @@ describe("Kepler Client", () => {
       .sessions()
       .then((caps) => expect(Object.keys(caps).length).toBeGreaterThan(1));
   });
+
+  it("can delete all contents", async () => {
+    let rs = await orbit.deleteAll();
+    for r in rs {
+      expect(r).toEqual({ success: true });
+    }
+    let list = orbit.list();
+    expect(list.data).toHaveLength(0);
+  });
+
 });

--- a/wrapper/src/orbit.ts
+++ b/wrapper/src/orbit.ts
@@ -221,6 +221,14 @@ export class OrbitConnection {
   async sessions(): Promise<{ [cid: string]: CapSummary }> {
     return await this.caps.get("all");
   }
+
+  async deleteAll(prefix: string = ""): Promise<Response[]> {
+    let kr = await this.kv.list(prefix);
+    if (!kr.ok) return [kr];
+    // @ts-ignore
+    let keys: string[] = kr.data;
+    return await Promise.all(keys.map(key => this.delete(key)));
+  }
 }
 
 /** Optional request parameters.

--- a/wrapper/src/orbit.ts
+++ b/wrapper/src/orbit.ts
@@ -226,7 +226,7 @@ export class OrbitConnection {
     let kr = await this.kv.list(prefix);
     if (!kr.ok) return [kr];
     // @ts-ignore
-    let keys: string[] = kr.data;
+    let keys: string[] = await kr.json();
     return await Promise.all(keys.map(key => this.delete(key)));
   }
 }


### PR DESCRIPTION
This PR adds a utility method to delete all contents following a particular prefix, i.e. `.deleteAll("folder1/")` would delete `"folder1/file_a"` and `"folder1/file_b"`. It executes this as a set of delete requests. Also adds a test.